### PR TITLE
feat: implement dark/light theme on all pages and subpages

### DIFF
--- a/app/(pages)/about/[id]/page.tsx
+++ b/app/(pages)/about/[id]/page.tsx
@@ -1,50 +1,54 @@
-"use client";
-import React from "react";
-import Image from "next/image";
-import { MdKeyboardBackspace } from "react-icons/md";
-import { SubHeading } from "@/app/components/heading";
-import Button from "@/app/components/button";
-import { useParams } from "next/navigation";
-import { Service } from "@/app/utils/mockData";
-import Link from "next/link";
+'use client';
+import React from 'react';
+import Image from 'next/image';
+import { MdKeyboardBackspace } from 'react-icons/md';
+import { SubHeading } from '@/app/components/heading';
+import Button from '@/app/components/button';
+import { useParams } from 'next/navigation';
+import { Service } from '@/app/utils/mockData';
+import Link from 'next/link';
 
 const AboutDetail = () => {
   const router = useParams();
   const { id } = router; // Get the `id` from the URL
-  console.log("id", router);
+  console.log('id', router);
 
   // Find the project with the matching `id`
   const serviceDetails = Service.find((service) => service.id == id);
 
-  console.log("serviceDetails", serviceDetails);
+  console.log('serviceDetails', serviceDetails);
 
   return (
-    <div className="relative w-full h-screen bg-black text-white">
-      <div className="absolute">
+    <div className='relative w-full h-screen bg-background text-foreground'>
+      <div className='absolute'>
         <Link
-          href="/about"
-          className="flex items-center justify-start font-light text-white text-sm hover:underline"
+          href='/about'
+          className='flex items-center justify-start font-light text-foreground text-sm hover:underline'
         >
-          <MdKeyboardBackspace className="text-3xl" />
+          <MdKeyboardBackspace className='text-3xl' />
         </Link>
       </div>
 
-      <div className="pt-2 md:pt-6 flex flex-col md:flex-row">
-        <div className="md:w-1/2 mt-10">
+      <div className='pt-2 md:pt-6 flex flex-col md:flex-row'>
+        <div className='md:w-1/2 mt-10'>
           <Image
-            src={serviceDetails?.image ?? ""}
+            src={serviceDetails?.image ?? ''}
             width={498}
             height={403}
-            alt="logo"
+            alt='logo'
           />
         </div>
 
-        <div className="pt-2 md:w-1/2 md:py-8 flex flex-col text-white items-start">
+        <div className='pt-2 md:w-1/2 md:py-8 flex flex-col text-foreground items-start'>
           <SubHeading text={serviceDetails?.title} />
-          <p className="text-sm font-normal md:text-base mt-4 mb-8">
+          <p className='text-sm font-normal md:text-base mt-4 mb-8'>
             {serviceDetails?.contentDetail}
           </p>
-          <Button text={"Schedule Appointment"} link="#" type="primary" />
+          <Button
+            text={'Schedule Appointment'}
+            link='/contact'
+            type='primary'
+          />
         </div>
       </div>
     </div>

--- a/app/(pages)/about/page.tsx
+++ b/app/(pages)/about/page.tsx
@@ -9,7 +9,7 @@ export default function About() {
     <section className='text-foreground min-h-screen'>
       {/* Hero Section */}
       <div className='mt-4 pb-8'>
-        <p className='text-sm font-normal uppercase mb-2 tracking-wide text-muted-foreground'>
+        <p className='text-sm font-normal uppercase mb-2 tracking-wide text-foreground'>
           DRIVEN BUSINESS ANALYST
         </p>
         <HeadingTwo
@@ -37,10 +37,10 @@ export default function About() {
       {/* Services Section */}
       <div className='pb-16'>
         <div className='mb-6'>
-          <h3 className='text-sm leading-[100%] mb-[10px] font-normal uppercase tracking-wide text-muted-foreground'>
+          <h3 className='text-sm leading-[100%] mb-[10px] font-normal uppercase tracking-wide text-foreground'>
             DRIVEN INSIGHT
           </h3>
-          <h2 className='text-4xl font-bold text-customPink mb-4'>
+          <h2 className='text-2xl md:text-4xl font-bold text-customPink mb-4'>
             Transforming business strategies with analytics
           </h2>
         </div>

--- a/app/(pages)/certification/page.tsx
+++ b/app/(pages)/certification/page.tsx
@@ -1,9 +1,50 @@
+'use client';
+
+import { HeadingTwo } from '@/app/components/heading';
+import Link from 'next/link';
+
+const certificateData = [
+  {
+    title: 'Qlik Sense Business Analyst Certification',
+    date: 'November 2023',
+    link: '#', // Replace with actual URL when available
+  },
+  {
+    title: 'Alteryx Designer Core Certified',
+    date: 'October 2023',
+    link: '#',
+  },
+  {
+    title: 'Certificate in Professional Marketing (CIM,UK)',
+    date: 'April 2022',
+    link: '#',
+  },
+];
+
 export default function Certification() {
   return (
-    <section className="bg-background text-foreground min-h-screen">
-      <main>
-        <h1 className="text-white">Certification Page</h1>;
-      </main>
-    </section>
+    <div className='min-h-screen bg-background text-foreground mt-8 mb-12'>
+      <HeadingTwo text='Certification' type='primary' className='mb-4' />
+
+      <div className='border border-customPink/80 p-6 mb-6 rounded-lg'>
+        {certificateData.map((certificate, index) => (
+          <div key={index} className='mb-[30px]'>
+            <div className='flex flex-col md:flex-row justify-between items-start md:items-center'>
+              <Link
+                href={certificate.link}
+                target='_blank'
+                rel='noopener noreferrer'
+                className='text-base font-bold text-primary hover:underline'
+              >
+                {certificate.title}
+              </Link>
+              <span className='text-foreground text-base font-normal'>
+                {certificate.date}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }

--- a/app/(pages)/experience/page.tsx
+++ b/app/(pages)/experience/page.tsx
@@ -6,7 +6,7 @@ export default function Experience() {
     <div className='min-h-screen bg-background text-foreground mt-8 mb-12'>
       <HeadingTwo text='Work Experience' type='primary' className='mb-4' />
 
-      <div className='border border-customPink/80 bg-card p-6 mb-6 rounded-lg'>
+      <div className='border border-customPink/80 p-6 mb-6 rounded-lg'>
         {experienceData.map((experience, index) => (
           <div key={index} className='mb-[30px]'>
             <div className='flex flex-col md:flex-row justify-between mb-2'>

--- a/app/(pages)/projects/[id]/page.tsx
+++ b/app/(pages)/projects/[id]/page.tsx
@@ -1,11 +1,11 @@
-"use client";
-import React from "react";
-import Image from "next/image";
-import { MdKeyboardBackspace } from "react-icons/md";
-import { HeadingTwo } from "@/app/components/heading";
-import Link from "next/link";
-import { useParams } from "next/navigation";
-import { Projects } from "@/app/utils/mockData";
+'use client';
+import React from 'react';
+import Image from 'next/image';
+import { MdKeyboardBackspace } from 'react-icons/md';
+import { HeadingTwo } from '@/app/components/heading';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { Projects } from '@/app/utils/mockData';
 
 const ProjectDetail = () => {
   const router = useParams();
@@ -15,79 +15,77 @@ const ProjectDetail = () => {
   const projectDetails = Projects.find((project) => project.id == id);
 
   return (
-    <div className="min-h-screen bg-black text-white py-8">
-      <div className="container mx-auto">
+    <div className='min-h-screen bg-background text-foreground py-8'>
+      <div className='container mx-auto'>
         {/* Back Button */}
-        <div className="mb-6">
+        <div className='mb-6 text-foreground'>
           <Link
-            href="/projects"
-            className="flex items-center space-x-2 text-white hover:text-gray-300 transition-colors duration-300"
+            href='/projects'
+            className='flex items-center space-x-2 hover:text-gray-300 transition-colors duration-300'
           >
-            <MdKeyboardBackspace className="text-2xl" />
+            <MdKeyboardBackspace className='text-2xl' />
           </Link>
         </div>
 
         {/* Project Details Container */}
-        <div className="space-y-8">
+        <div className='space-y-8'>
           {/* Project Header */}
           <div>
-            <p className="text-sm md:text-base text-white font-bold mb-2">
+            <p className='text-sm md:text-base font-bold mb-2'>
               {projectDetails?.dateRange}
             </p>
             <HeadingTwo
-              text={projectDetails?.mobileTitle ?? ""}
-              type="primary"
-              className="font-bold mb-10 md:mb-20"
+              text={projectDetails?.mobileTitle ?? ''}
+              type='primary'
+              className='font-bold mb-10 md:mb-20'
             />
           </div>
 
           {/* Project Summary Section */}
-          <section className="rounded-lg shadow-md">
-            <h2 className="text-xl md:text-3xl font-bold mb-2 text-customPink">
+          <section>
+            <h2 className='text-xl md:text-3xl font-bold mb-2 text-customPink'>
               Project Summary
             </h2>
-            <p className="text-base leading-relaxed text-white font-normal">
+            <p className='text-base leading-relaxed font-normal'>
               {projectDetails?.summary}
             </p>
           </section>
 
           {/* Main Project Image */}
 
-          <div className="grid grid-col-1 md:grid-cols-2 gap-4 max-w-full h-fit overflow-hidden">
-            <div className="col-span-1 md:col-span-2 md:row-span-1">
+          <div className='grid grid-col-1 md:grid-cols-2 gap-4 max-w-full h-fit overflow-hidden'>
+            <div className='col-span-1 md:col-span-2 md:row-span-1'>
               <Image
-                src={projectDetails?.backgroundImages[0] ?? ""}
+                src={projectDetails?.backgroundImages[0] ?? ''}
                 alt={`${projectDetails?.title} main project image`}
                 width={1086}
                 height={304}
-                className="w-full rounded-lg"
+                className='w-full rounded-lg'
               />
             </div>
-            <div className="aspect-video relative">
+            <div className='aspect-video relative'>
               <Image
-                src={projectDetails?.backgroundImages[1] ?? ""}
+                src={projectDetails?.backgroundImages[1] ?? ''}
                 alt={`${projectDetails?.title} project image 2`}
                 fill
-                className="object-cover rounded-lg"
+                className='object-cover rounded-lg'
               />
             </div>
-            <div className="aspect-video relative">
+            <div className='aspect-video relative'>
               <Image
-                src={projectDetails?.backgroundImages[2] ?? ""}
+                src={projectDetails?.backgroundImages[2] ?? ''}
                 alt={`${projectDetails?.title} project image 3`}
                 fill
-                className="object-cover rounded-lg"
+                className='object-cover rounded-lg'
               />
             </div>
           </div>
           {/* Tools Used Section */}
           <div>
-            <h2 className="text-xl md:text-3xl font-bold mb-2 text-customPink">
+            <h2 className='text-xl md:text-3xl font-bold mb-2 text-customPink'>
               Tools Used
             </h2>
-            <p className="text-base text-white font-normal">
-              {projectDetails?.tools}
-            </p>
+            <p className='text-base font-normal'>{projectDetails?.tools}</p>
           </div>
         </div>
       </div>

--- a/app/(pages)/projects/page.tsx
+++ b/app/(pages)/projects/page.tsx
@@ -9,7 +9,7 @@ export default function ProjectsPage() {
       <div className='max-w-6xl mx-auto'>
         {/* Header */}
         <div className='mb-8'>
-          <p className='text-base text-muted-foreground font-bold mt-2 mb-1'>
+          <p className='text-base text-foreground font-bold mt-2 mb-1'>
             Harnessing data for strategic growth
           </p>
           <HeadingTwo text='Driving Business Success Through' type='primary' />

--- a/app/components/button.tsx
+++ b/app/components/button.tsx
@@ -1,9 +1,9 @@
 const Button = ({
   text,
-  link = "#",
-  type = "secondary",
+  link = '#',
+  type = 'secondary',
   form = false,
-  className = "",
+  className = '',
   downloadFile,
 }: {
   text: string;
@@ -18,13 +18,13 @@ const Button = ({
       href={downloadFile || link}
       download={downloadFile ? true : undefined}
       className={`${
-        type === "primary"
-          ? "bg-customPink hover:bg-customPink/50 hover:border-transparent hover:text-white text-white text-center border-2"
-          : "bg-black text-customPink border-2 text-center border-customPink hover:border-customPink/50 hover:text-white"
+        type === 'primary'
+          ? 'bg-customPink hover:bg-customPink/80 hover:border-customPink/80 text-white text-center border-2 border-customPink'
+          : 'bg-background text-customPink border text-center border-customPink hover:bg-customPink hover:text-white'
       } ${
-        form ? "w-full" : ""
-      } border-customPink rounded-lg text-[12px] md:text-[16px] font-bold duration-200 transition-all p-2 md:py-2.5 md:px-4 ${
-        className || ""
+        form ? 'w-full' : ''
+      } rounded-lg text-[12px] md:text-[16px] font-bold duration-200 transition-all p-2 md:py-2.5 md:px-4 ${
+        className || ''
       }`}
     >
       {text}

--- a/app/components/heading.tsx
+++ b/app/components/heading.tsx
@@ -1,5 +1,5 @@
-import { inknut_Antiqua } from "@/app/utils/font";
-import { inter } from "@/app/utils/font";
+import { inknut_Antiqua } from '@/app/utils/font';
+import { inter } from '@/app/utils/font';
 
 export const HeadingOne = ({
   text,
@@ -13,7 +13,7 @@ export const HeadingOne = ({
   return (
     <h1
       className={`${inknut_Antiqua.className} ${
-        type === "secondary" ? "text-white" : "text-customPink"
+        type === 'secondary' ? 'text-white' : 'text-customPink'
       } text-[24px] md:text-[50px] font-semibold text-center leading-tight ${hide}`}
     >
       {text}
@@ -33,7 +33,7 @@ export const HeadingTwo = ({
   return (
     <h1
       className={`${inter.className} ${
-        type === "secondary" ? "text-white" : "text-customPink"
+        type === 'secondary' ? 'text-white' : 'text-customPink'
       } text-[24px] md:text-[48px] font-semibold text-start leading-tight ${className}`}
     >
       {text}
@@ -53,7 +53,7 @@ export const Heading30 = ({
   return (
     <h1
       className={`${inter.className} ${
-        type === "secondary" ? "text-white" : "text-customPink"
+        type === 'secondary' ? 'text-white' : 'text-customPink'
       } text-[22px] md:text-[30px] font-semibold text-start leading-tight pb-2 ${hide}`}
     >
       {text}
@@ -71,7 +71,7 @@ export const HeadingThree = ({
   return (
     <h1
       className={`${inter.className} ${
-        type === "secondary" ? "text-white" : "text-customPink"
+        type === 'secondary' ? 'text-white' : 'text-customPink'
       } text-[18px] md:text-[22px] font-semibold text-start leading-tight pb-2`}
     >
       {text}
@@ -82,7 +82,7 @@ export const HeadingThree = ({
 export const SubHeading = ({ text }: { text: string | undefined }) => {
   return (
     <p
-      className={`${inter.className} text-white text-[12px] sm:text-[14px] md:text-[14px] lg:text-[16px] font-bold mt-2 text-center`}
+      className={`${inter.className} text-[12px] sm:text-[14px] md:text-[14px] lg:text-[16px] font-bold mt-2 text-center`}
     >
       {text}
     </p>

--- a/app/components/homenav.tsx
+++ b/app/components/homenav.tsx
@@ -1,67 +1,67 @@
-import Link from "next/link";
+import Link from 'next/link';
 const Homenav = () => {
   return (
-    <nav className="mt-8 sm:mt-2 md:mt-2 lg:mt-2">
-      <ul className="flex flex-wrap justify-center gap-6 sm:gap-3 md:gap-3 lg:gap-4 text-white bg-black rounded-full border border-gray-800 p-4 text-sm sm:text-base">
+    <nav className='mt-8 sm:mt-2 md:mt-2 lg:mt-2'>
+      <ul className='flex flex-wrap justify-center gap-4 md:gap-3 lg:gap-4 text-forground font-normal bg-background rounded-full border border-gray-800 p-4 text-sm sm:text-base'>
         <li>
           <Link
-            href="/about"
-            className="hover:text-customPink transition-colors"
+            href='/about'
+            className='hover:text-customPink transition-colors'
           >
             About
           </Link>
         </li>
-        <span className="text-gray-600 pointer-events-none cursor-default">
+        <span className='text-gray-600 pointer-events-none cursor-default'>
           |
         </span>
         <li>
           <Link
-            href="/experience"
-            className="hover:text-customPink transition-colors"
+            href='/experience'
+            className='hover:text-customPink transition-colors'
           >
             Work Experience
           </Link>
         </li>
-        <span className="text-gray-600 pointer-events-none cursor-default">
+        <span className='text-gray-600 pointer-events-none cursor-default'>
           |
         </span>
         <li>
           <Link
-            href="/skills"
-            className="hover:text-customPink transition-colors"
+            href='/skills'
+            className='hover:text-customPink transition-colors'
           >
             Skills
           </Link>
         </li>
-        <span className="text-gray-600 pointer-events-none cursor-default">
+        <span className='text-gray-600 pointer-events-none cursor-default'>
           |
         </span>
         <li>
           <Link
-            href="/certification"
-            className="hover:text-customPink transition-colors"
+            href='/certification'
+            className='hover:text-customPink transition-colors'
           >
             Certification
           </Link>
         </li>
-        <span className="text-gray-600 pointer-events-none cursor-default">
+        <span className='text-gray-600 pointer-events-none cursor-default'>
           |
         </span>
         <li>
           <Link
-            href="/projects"
-            className="hover:text-customPink transition-colors"
+            href='/projects'
+            className='hover:text-customPink transition-colors'
           >
             Projects
           </Link>
         </li>
-        <span className="text-gray-600 pointer-events-none cursor-default">
+        <span className='text-gray-600 pointer-events-none cursor-default'>
           |
         </span>
         <li>
           <Link
-            href="/contact"
-            className="hover:text-customPink transition-colors"
+            href='/contact'
+            className='hover:text-customPink transition-colors'
           >
             Contact
           </Link>

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -23,7 +23,9 @@ function Navbar() {
 
         <div className='flex items-center gap-4'>
           {/* Theme Toggle */}
-          <ThemeToggle />
+          <div className='md:hidden'>
+            <ThemeToggle />
+          </div>
 
           {/* Hamburger Menu Button */}
           <button
@@ -127,6 +129,11 @@ function Navbar() {
             </Link>
           </li>
         </ul>
+
+        {/* Theme Toggle */}
+        <div className='hidden md:block'>
+          <ThemeToggle />
+        </div>
       </div>
 
       {/* Mobile Menu */}

--- a/app/components/projectCard.tsx
+++ b/app/components/projectCard.tsx
@@ -24,17 +24,17 @@ const ProjectCard = ({
   backgroundImages,
 }: ProjectCardProps) => {
   return (
-    <div className='flex flex-col justify-left bg-card text-foreground mb-4'>
+    <div className='flex flex-col justify-left text-foreground mb-4'>
       <Link href={`/projects/${id}`}>
         <Image
           alt='project-image'
           src={backgroundImage}
-          width={541}
+          width={561}
           height={337}
         />
       </Link>
       <div className='pt-2 pb-4'>
-        <p className='text-sm md:text-base font-normal md:font-bold mt-2 mb-1 text-muted-foreground'>
+        <p className='text-sm md:text-base font-normal md:font-bold mt-2 mb-1 text-foreground'>
           {dateRange}
         </p>
         <Heading30 text={title} type='primary' hide='hidden md:block' />
@@ -44,7 +44,7 @@ const ProjectCard = ({
           <span className='text-lg font-bold text-foreground'>
             Tools used:{' '}
           </span>
-          <span className='text-base md:text-lg font-normal text-muted-foreground'>
+          <span className='text-base md:text-lg font-normal text-foreground'>
             {tools}
           </span>
         </div>

--- a/app/components/services.tsx
+++ b/app/components/services.tsx
@@ -1,25 +1,25 @@
-import Link from "next/link";
+import Link from 'next/link';
 
 interface ServiceProps {
-  id: string,
+  id: string;
   image: string;
   title: string;
   content: string;
 }
 
-const Services = ({ id, image, title, content, }: ServiceProps) => {
+const Services = ({ id, image, title, content }: ServiceProps) => {
   return (
-    <div className="flex flex-col justify-left bg-white pb-4">
+    <div className='flex flex-col justify-left bg-background text-foreground pb-4'>
       <Link href={`/about/${id}`}>
         <img
-          className="w-full cursor-pointer hover:opacity-90 transition-opacity"
+          className='w-full cursor-pointer hover:opacity-90 transition-opacity'
           src={image}
           alt={title}
         />
       </Link>
-      <div className="px-2 pt-4">
-        <p className="font-bold text-start text-[19px] ml-2">{title}</p>
-        <p className="font-medium text-start text-[16px] ml-2">{content}</p>
+      <div className='px-2 pt-4 bg-background text-foreground'>
+        <p className='font-bold text-start text-[19px]'>{title}</p>
+        <p className='font-medium text-start text-[16px]'>{content}</p>
       </div>
     </div>
   );

--- a/app/components/theme-toggle.tsx
+++ b/app/components/theme-toggle.tsx
@@ -14,7 +14,7 @@ export function ThemeToggle() {
 
   if (!mounted) {
     return (
-      <button className='w-9 h-9 rounded-md border border-border bg-background hover:bg-accent'>
+      <button className='flex items-center gap-2 px-3 py-2 rounded-md border border-border bg-background hover:bg-accent'>
         <span className='sr-only'>Toggle theme</span>
       </button>
     );
@@ -23,14 +23,14 @@ export function ThemeToggle() {
   return (
     <button
       onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-      className='w-9 h-9 rounded-md border border-border bg-background hover:bg-accent transition-colors flex items-center justify-center'
+      className='flex items-center gap-2 px-3 py-2 rounded-md border border-border bg-background hover:bg-accent transition-colors'
     >
       {theme === 'light' ? (
         <Moon className='h-4 w-4 text-foreground' />
       ) : (
         <Sun className='h-4 w-4 text-foreground' />
       )}
-      <span className='sr-only'>Toggle theme</span>
+      <span className='text-sm text-foreground'>Mode</span>
     </button>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,18 +6,23 @@ import { HeadingOne, SubHeading } from '@/app/components/heading';
 import Image from 'next/image';
 import Link from 'next/link';
 import Homenav from '@/app/components/homenav';
+import { ThemeToggle } from './components/theme-toggle';
 
 export default function Home() {
   return (
     <section className='bg-background text-foreground h-screen overflow-hidden'>
-      <div className='flex flex-row items-center justify-center md:justify-end gap-6 p-4 md:p-6'>
-        {/* <Button text="Download CV" link="/cv" type="secondary" /> */}
-        <Button
-          text='Download CV'
-          downloadFile='/doc/deborah-oyeyemi-resume.pdf'
-          type='secondary'
-        />
-        <Button text='Contact Me' link='/contact' type='primary' />
+      <div className='flex flex-row items-center justify-between md:justify-between gap-4 p-4 md:p-6'>
+        {/* Theme Toggle */}
+        <ThemeToggle />
+        <div className='flex flex-row gap-4'>
+          {/* <Button text="Download CV" link="/cv" type="secondary" /> */}
+          <Button
+            text='Download CV'
+            downloadFile='/doc/deborah-oyeyemi-resume.pdf'
+            type='secondary'
+          />
+          <Button text='Contact Me' link='/contact' type='primary' />
+        </div>
       </div>
       <main className='flex flex-col justify-center h-[85vh] items-center p-8 md:p-10 lg:p-6'>
         <div className='flex flex-col items-center justify-center gap-8 sm:gap-8 md:gap-8 lg:gap-8'>


### PR DESCRIPTION
## Description
- Completely refactored entire project pages and detail pages to seamlessly adopt the dark and light theme.
- Developed the Certifications page and made each certificate title a clickable link that opens in a new tab (placeholders added for now, to be replaced once actual links are available).

## Type of Change
- [x] Bug fix
- [x] Feature
- [x] Enhancement
- [ ] Documentation update

## Screenshots/Recordings
<img width="1360" height="763" alt="image" src="https://github.com/user-attachments/assets/165103cf-fe2f-4cb2-9814-34b89644cf93" />
<img width="1360" height="763" alt="image" src="https://github.com/user-attachments/assets/061f717b-569c-4327-8b94-58e588ffd89e" />
<img width="1360" height="763" alt="image" src="https://github.com/user-attachments/assets/0925cebd-2d15-4cfa-a39f-2a03fa438ab0" />
<img width="1360" height="763" alt="image" src="https://github.com/user-attachments/assets/76714f98-6e7c-4ad5-89ce-8a22bc5a3d7b" />


## Additional Notes
<!-- Any additional context, concerns, or questions -->

## Related Issues
<!-- Link any related issues (e.g., fixes #123, closes #456) -->

## Checklist
- [x] I have tested the code and verified it works as expected.
- [ ] I have updated the documentation(README.md files) if needed.
- [ ] I have added or updated tests (if applicable).